### PR TITLE
fix: 調整版面排版及更新個人簡介內容

### DIFF
--- a/assets/style/all.css
+++ b/assets/style/all.css
@@ -44779,8 +44779,20 @@ body {
   background: url(../images/home.jpg) no-repeat;
   background-position: center;
   background-size: cover;
-  height: 70vh;
+  height: 50vh;
   width: 100%;
+}
+
+@media (min-width: 768px) {
+  .hero {
+    height: 40vh;
+  }
+}
+
+@media (min-width: 1400px) {
+  .hero {
+    height: 35vh;
+  }
 }
 
 #about .personal-photo {

--- a/index.html
+++ b/index.html
@@ -76,8 +76,8 @@
 
 
   <div class="d-flex flex-column m-0 ms-lg-60 p-0">
-    <section id="home" class="hero d-flex align-items-center pt-12 mb-24">
-      <div class="container pt-28">
+    <section id="home" class="hero d-flex align-items-center mb-24">
+      <div class="container">
         <h2 class="text-center fs-12 fw-bold lh-base text-white">Iris Wang</h2>
         <h3 class="text-center fs-8 lh-base text-white">Front - End Web Developer</h3>
       </div>
@@ -87,39 +87,38 @@
       <div class="container">
         <h3 id="About" class="text-center fs-8 fw-bold lh-base mb-8">關於我</h3>
         <div class="row">
-          <div class="col-lg-4 mb-4 mb-md-2">
+          <div class="col-sm-8 offset-sm-2 col-md-6 offset-md-3 col-lg-4 offset-lg-0 mb-4 mb-md-2">
             <img src="./assets/images/iriswang.jpg" alt="個人照" class="img-fluid">
           </div>
-          <div class="col-lg-8 d-flex justify-content-between flex-column py-4 px-8">
+          <div class="col-lg-8 d-flex justify-content-between flex-column gap-4 py-4 px-8">
             <div>
               <h4 class="fw-bold">網頁開發經驗</h4>
               <p class="m-0">
                 擁有 2 年半的網頁開發經驗，熟練掌握 HTML、CSS、JavaScript 等前端技術，並運用 Vue 3、Vite 等現代開發工具進行開發。具備實現 RWD 響應式網頁設計的經驗，並熟悉使用 CSS
-                預處理器（Sass/SCSS）和流行框架（TailwindCSS、Bootstrap 5）。具備 UI/UX 設計能力，能夠與團隊共同打造符合需求的網頁介面。了解基本後端知識，能進行 API
-                串接和數據交互，並熟練使用 Git 和 GitHub 進行版本控制和團隊協作。
+                預處理器（Sass/SCSS）和流行框架（TailwindCSS、Bootstrap 5）。了解後端基礎知識，能進行 API 串接和數據交互，並熟練使用 Git 和 GitHub 進行版本控制和團隊協作。
               </p>
             </div>
-            <div class="row mb-10 mb-md-8 mb-lg-4">
+            <div class="row">
               <div class="col-lg-8">
-                <ul class="list-unstyled">
-                  <li class="mb-1 mb-md-4"><span class="material-icons text-warning">
+                <ul class="list-unstyled mb-0">
+                  <li class="mb-1 mb-md-2"><span class="material-icons text-warning">
                       chevron_right
                     </span><span>王盈茹 Iris Wang</span></li>
-                  <li class="mb-1 mb-md-4"><span class="material-icons text-warning">
+                  <li class="mb-1 mb-md-2"><span class="material-icons text-warning">
                       chevron_right
                     </span><span>網頁前端工程師 Front - End Web Developer</span></li>
-                  <li class="mb-1 mb-md-4"><span class="material-icons text-warning">
+                  <li class="mb-1 mb-md-2"><span class="material-icons text-warning">
                       chevron_right
                     </span><span>台灣 台北市 Taipei City, Taiwan</span></li>
                 </ul>
               </div>
               <div class="col-lg-4">
-                <ul class="list-unstyled">
-                  <li class="mb-1 mb-md-4 light-up"><span class="material-icons text-warning">
+                <ul class="list-unstyled mb-0">
+                  <li class="mb-1 mb-md-2 light-up"><span class="material-icons text-warning">
                       chevron_right
                     </span><a href="mailto:iriswang1091@gmail.com" class="text-warning text-decoration-none">Email<i
                         class="bi bi-envelope-at-fill text-warning"></i></a></li>
-                  <li class="mb-1 mb-md-4 light-up"><span class="material-icons text-warning">
+                  <li class="mb-1 mb-md-2 light-up"><span class="material-icons text-warning">
                       chevron_right
                     </span><a href="https://github.com/WangYingJu" target="_blank"
                       class="text-warning text-decoration-none">GitHub<i class="bi bi-github text-warning"></i></a></li>
@@ -129,8 +128,8 @@
             <div>
               <h4 class="fw-bold">個人特質</h4>
               <p class="m-0">
-                擁有 8 年設計經驗，並具備豐富的跨部門協作經驗，能有效促進團隊間的技術溝通，提升專案執行效率。持續學習新技術並將其應用於實際工作中，並成功完成多個網頁開發專案。目前專注於深入學習 Vue 框架，並加強
-                JavaScript 邏輯，藉由開發個人作品集網站與 side project，進一步提升開發技能和實務經驗。
+                擁有 8 年設計經驗，並具備豐富的跨部門協作經驗，能有效促進團隊間的技術溝通，提升專案執行效率。持續學習新技術並將其應用於實際工作中，並成功完成多個網頁開發專案。目前專注於深入學習 Vue 框架及
+                JavaScript 邏輯，藉由開發個人作品集網站與 <a href="https://wangyingju.github.io/USphere" target="_blank" class="text-warning">Side Project</a>，進一步提升開發技能和實務經驗。
               </p>
             </div>
           </div>
@@ -142,18 +141,9 @@
       <div class="container p-8">
         <h3 class="text-center fs-8 fw-bold lh-base mb-8">專業技能</h3>
         <div class="row">
-          <div class="col-lg-4">
-            <h4 class="text-warning mt-4">視覺設計</h4>
-            <p>具備扎實的視覺設計能力，熟悉各類設計工具與排版原則</p>
-            <ul>
-              <li>精通 Photoshop 進行視覺設計、Banner 設計、海報設計</li>
-              <li>精通 Illustrator 進行平面設計、字體設計</li>
-              <li>熟悉 Figma 進行網頁 UI / UX 規劃與設計</li>
-            </ul>
-          </div>
-          <div class="col-lg-4">
+          <div class="col-xxl-4 col-md-6 col-sm-12">
             <h4 class="text-warning mt-4">網頁設計</h4>
-            <p>能夠獨立開發與實現網頁版面配置</p>
+            <p>具有與企劃溝通協作之能力，並能獨立開發實現網頁排版配置</p>
             <ul>
               <li>配合 UI / UX 設計師，切出符合需求的 Layout</li>
               <li>熟悉 HTML5 和 CSS3，具備網頁設計能力</li>
@@ -163,9 +153,9 @@
               <li>具備 RWD 響應式設計的經驗，優化不同裝置的顯示效果</li>
             </ul>
           </div>
-          <div class="col-lg-4">
+          <div class="col-xxl-4 col-md-6 col-sm-12">
             <h4 class="text-warning mt-4">前端技術</h4>
-            <p>具備前端開發實務經驗，實現動態網頁</p>
+            <p>具備前端開發實務經驗，並與後端溝通及協作，實現動態網頁</p>
             <ul>
               <li>運用 JavaScript ES6+，掌握現代語法與最佳實踐</li>
               <li>Vue 3 + Vue Router 進行前端開發，整合 Pinia 進行狀態管理</li>
@@ -173,31 +163,33 @@
               <li>Fetch API / Axios 串接 API，處理非同步資料</li>
               <li>運用 vee-validate + Yup Schema 進行表單驗證，確保資料完整性</li>
               <li>採用 JWT 驗證進行身份驗證，確保應用安全性</li>
-            </ul>
-          </div>
-          <div class="col-lg-4">
-            <h4 class="text-warning mt-4">後端技術</h4>
-            <p>了解後端基礎概念，能與後端開發人員協作</p>
-            <ul>
-              <li>曾使用 Node.js 及 Express.js 開發簡單後端服務</li>
               <li>使用 Mockoon 進行 API 模擬與測試</li>
-              <li>理解 RESTful API 概念，能與前端進行有效數據交互</li>
             </ul>
           </div>
-          <div class="col-lg-4">
-            <h4 class="text-warning mt-4">資料庫</h4>
-            <p>了解資料庫基礎知識與操作</p>
-            <ul>
-              <li>使用過 MongoDB，能夠進行 CRUD Operations</li>
-            </ul>
-          </div>
-          <div class="col-lg-4">
+          <div class="col-xxl-4 col-md-6 col-sm-12">
             <h4 class="text-warning mt-4">版本控制</h4>
             <p>具備版本控制與團隊協作經驗，能夠有效管理專案代碼</p>
             <ul>
               <li>熟悉 Git 進行版本控制</li>
               <li>原始碼代管服務平台使用 GitHub 進行協作</li>
-              <li>了解 Linux 指令，能夠透過指令進行專案管理</li>
+            </ul>
+          </div>
+          <div class="col-xxl-4 col-md-6 col-sm-12">
+            <h4 class="text-warning mt-4">溝通協作</h4>
+            <p>曾擔任部門窗口，能適時調整溝通方式，確保跨部門協作順暢</p>
+            <ul>
+              <li>能與企劃人員協作，確認網頁開發需求與規格</li>
+              <li>具備設計實務經驗，能與 UI / UX 設計師討論設計可行性</li>
+              <li>了解後端與資料庫基礎知識，能與後端工程師溝通與協作</li>
+            </ul>
+          </div>
+          <div class="col-xxl-4 col-md-6 col-sm-12">
+            <h4 class="text-warning mt-4">視覺設計</h4>
+            <p>具備扎實的視覺設計能力，熟悉各類設計工具與排版原則</p>
+            <ul>
+              <li>精通 Photoshop 進行視覺設計、Banner 設計、海報設計</li>
+              <li>精通 Illustrator 進行平面設計、字體設計</li>
+              <li>熟悉 Figma 進行網頁 UI / UX 規劃與設計</li>
             </ul>
           </div>
         </div>
@@ -214,7 +206,7 @@
               <h4 class="text-warning">2023 網頁全端開發</h4>
               <h5 class="badge text-dark fs-4 bg-light  px-3 py-1">2023/6 - 至今</h5>
               <p><em>udemy</em></p>
-              <p>完成進階 JavaScript、Git、Node.js 和 Express.js 的學習，目前使用 Vite + Vue + Router + Pinia 正在進行 Side Project 開發。</p>
+              <p>完成進階 JavaScript、Git、Node.js 和 Express.js 的學習，目前使用 Vite + Vue + Router + Pinia 正在進行 <a href="https://wangyingju.github.io/USphere" target="_blank" class="text-warning">Side Project</a> 開發。</p>
             </div>
             <div class="resume-item px-5 pb-5 border-gray border-2 border-start position-relative ms-4">
               <h4 class="text-warning">JS 工程師養成直播班</h4>
@@ -249,12 +241,11 @@
                 <li>管理：
                   <ul>
                     <li>負責網頁工單排程、進度追蹤與人員工作分配</li>
-                    <li>作為跨部門、跨分公司溝通窗口，調整溝通方式以適應不同執行人員需求</li>
-                    <li>代理主管執行行政事務，參與公司例會</li>
+                    <li>作為跨部門與分公司溝通窗口，依執行人員需求調整溝通方式，並代理主管處理行政事務及參與例會</li>
                     <li>新人網頁開發指導與 code review，幫助新人在 3 至 6 個月內獨立作業</li>
                   </ul>
                 </li>
-                <li>網頁:
+                <li>網頁開發:
                   <ul>
                     <li>開發 2 套活動頁模板、2 套遊戲官網模板及 1 套集團活動頁模板，並將功能元件化（6 組）</li>
                     <li>與技術及行銷部門合作，開發並完成 12 個遊戲活動頁，並整合 jQuery 及第三方 JS 套件</li>
@@ -269,8 +260,8 @@
               <h5 class="badge text-dark fs-4 bg-light  px-3 py-1">2020/9 - 2022/2</h5>
               <p><em>東森全球事業股份有限公司 &​ 東森得易購股份有限公司</em></p>
               <ul>
-                <li>網頁：購物網活動網頁設計及切版，共完成 20 個網頁專案</li>
-                <li>APP 遊戲開發：與技術研發部門協同合作及溝通需求、遊戲 UI 介面設計、建構遊戲玩法組織，共完成 5 個 APP 遊戲</li>
+                <li>網頁開發：購物網活動網頁設計及切版、Banner 設計</li>
+                <li>APP遊戲開發：與技術部門協作及溝通需求、建構遊戲玩法組織、遊戲 UI 介面設計</li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
## Summary

1. 更新 版頭在各裝置的vh
2. 更新 個人介紹區塊的文案及各裝置的大小及排版
3. 更新 專業技能在各裝置的排版及順序

<img width="1057" alt="image" src="https://github.com/user-attachments/assets/6bd64ad1-129a-46ce-96cd-352813d70df7" />

<img width="1033" alt="image" src="https://github.com/user-attachments/assets/15c3366a-da37-4abb-94eb-d22fd5666b82" />

<img width="1029" alt="image" src="https://github.com/user-attachments/assets/2057b4a6-0fc8-412d-96f7-7faa74bc3978" />


## How to test

live server
